### PR TITLE
Resolve to_prepare deprecation warning in Rails 5.0

### DIFF
--- a/lib/haml_user_tags/rails/reloader.rb
+++ b/lib/haml_user_tags/rails/reloader.rb
@@ -3,8 +3,21 @@ module HamlUserTags
     initializer "haml_user_tags.enable_reloading" do
       watcher = ActiveSupport::FileUpdateChecker.new([], "#{Rails.root}/app/views/helpers" => %w{haml}) {}
       Rails.application.reloaders << watcher
-      ActionDispatch::Reloader.to_prepare do
+      reloader_class.to_prepare do
         watcher.execute_if_updated
+      end
+    end
+
+    private
+
+    def reloader_class
+      # Rails 5.0 says:
+      # DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1
+      # (use ActiveSupport::Reloader.to_prepare instead)
+      if ActiveSupport.version.release >= Gem::Version.new('5')
+        ActiveSupport::Reloader
+      else
+        ActionDispatch::Reloader
       end
     end
   end

--- a/lib/haml_user_tags/rails/reloader.rb
+++ b/lib/haml_user_tags/rails/reloader.rb
@@ -14,7 +14,7 @@ module HamlUserTags
       # Rails 5.0 says:
       # DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1
       # (use ActiveSupport::Reloader.to_prepare instead)
-      if ActiveSupport.version.release >= Gem::Version.new('5')
+      if ActiveSupport::VERSION::MAJOR >= 5
         ActiveSupport::Reloader
       else
         ActionDispatch::Reloader


### PR DESCRIPTION
The method ActionDispatch::Reloader.to_prepare is deprecated and writes the following deprecation warning to the log
```DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1 (use ActiveSupport::Reloader.to_prepare instead)```