### PR TITLE
use Module#prepend instead of alias_method_chain due to deprecation warning

### DIFF
--- a/lib/haml_user_tags/rails/helpers.rb
+++ b/lib/haml_user_tags/rails/helpers.rb
@@ -1,5 +1,12 @@
 module HamlUserTags
   module Helpers
+    module AttributesWithIndifference
+      def attributes_hash *args
+        ActiveSupport::HashWithIndifferentAccess.new super(*args)
+      end
+    end
+    prepend AttributesWithIndifference
+
     alias_method :include_tags_without_rails, :include_tags
     # Override the base include_tags to take advantage of Rails' template
     # location features
@@ -9,13 +16,6 @@ module HamlUserTags
       template = lookup_context.find_template(path, [], true)
       HamlUserTags::Engine.new(template.source, :filename => template.identifier).extend_object self
       nil
-    end
-
-    class << self
-      def attributes_hash_with_indifference *args
-        ActiveSupport::HashWithIndifferentAccess.new attributes_hash_without_indifference *args
-      end
-      alias_method_chain :attributes_hash, :indifference
     end
   end
 end


### PR DESCRIPTION
Hi there, I got this deprecation warning and fixed it in this PR.
If you have a chance, please review.

```
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <top (required)> at /Users/chris/src/xflagstudio/anime-server/config/application.rb:8)
/Users/chris/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/core_ext/module/aliasing.rb:27:in `alias_method_chain'
  /Users/chris/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/haml_user_tags-0.9.3/lib/haml_user_tags/rails/helpers.rb:18:in `singleton class'
  /Users/chris/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/haml_user_tags-0.9.3/lib/haml_user_tags/rails/helpers.rb:14:in `<module:Helpers>'
```